### PR TITLE
Update s3bench.go

### DIFF
--- a/s3bench.go
+++ b/s3bench.go
@@ -43,6 +43,7 @@ import (
 )
 
 const (
+	version      = "Version 1.0"
 	opRead       = "Read"
 	opWrite      = "Write"
 	opRangedRead = "Ranged-Read"
@@ -159,6 +160,7 @@ func main() {
 
 		verbose: *verbose,
 	}
+	fmt.Println(version)
 	fmt.Println(params)
 	fmt.Println()
 


### PR DESCRIPTION
Added very basic version code.
Needed because selab-cb5 etc. have random old versions of it floating around, and it's unclear if they're 'current' or not.